### PR TITLE
TMS-1113: Padding fix for pages first component

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1113: Remove top-padding for first component in page
+
 ## [1.1.2] - 2025-02-24
 
 - TMS-1110: Minor style changes

--- a/assets/styles/views/_page.scss
+++ b/assets/styles/views/_page.scss
@@ -1,7 +1,10 @@
 .page {
     // Remove paddings for first component
-    &__hero-section + .section,
     &__hero-section:has(+ .section) {
+        padding-bottom: 0;
+    }
+
+    &__hero-section + .section {
         padding-top: 0;
     }
 

--- a/assets/styles/views/_page.scss
+++ b/assets/styles/views/_page.scss
@@ -1,4 +1,10 @@
 .page {
+    // Remove paddings for first component
+    &__hero-section + .section,
+    &__hero-section:has(+ .section) {
+        padding-top: 0;
+    }
+
     &__hero {
         display: flex;
         justify-content: center;

--- a/partials/page.dust
+++ b/partials/page.dust
@@ -2,7 +2,7 @@
 
 {<content}
     <main class="main-content" id="main-content">
-        <section class="section {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
+        <section class="section page__hero-section {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
             <div class="container">
                 <div class="columns">
                     <div class="column is-12">


### PR DESCRIPTION
Severa-ID: 2108
Severa-kuvaus: TMS-1113 Pääotsikon ja sitä seuraavan komponentin väli
Task: https://hiondigital.atlassian.net/browse/TMS-1113

<!--- Provide a general summary of your changes in the Title above -->

## Description

Decrease top-padding after pages main heading if components are used as the first elements

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

