### PR TITLE
TMS-1116: Fix for single event page hero price if free

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1116: Fix for single event page hero price if free
+
 ## [1.1.2] - 2025-02-24
 
 - TMS-1110: Minor style changes

--- a/lib/ACF/AlterKeyFiguresFields.php
+++ b/lib/ACF/AlterKeyFiguresFields.php
@@ -37,12 +37,12 @@ class AlterKeyFiguresFields {
         ];
 
         $background_image = ( new \Geniem\ACF\Field\Image( $strings['background_image']['label'] ) )
-            ->set_key( "background_image" )
+            ->set_key( 'background_image' )
             ->set_name( 'background_image' )
             ->set_wrapper_width( 50 );
 
         $text_background_image = ( new \Geniem\ACF\Field\Image( $strings['text_background_image']['label'] ) )
-            ->set_key( "text_background_image" )
+            ->set_key( 'text_background_image' )
             ->set_name( 'text_background_image' )
             ->set_wrapper_width( 50 );
 

--- a/lib/ACF/AlterManualEventGroup.php
+++ b/lib/ACF/AlterManualEventGroup.php
@@ -79,7 +79,7 @@ class AlterManualEventGroup {
                 'label'        => 'Linkki',
                 'instructions' => '',
             ],
-            'event_video'    => [
+            'event_video'   => [
                 'label'        => 'Videoupotus',
                 'instructions' => '',
             ],

--- a/lib/ACF/AlterManualEventGroup.php
+++ b/lib/ACF/AlterManualEventGroup.php
@@ -90,33 +90,33 @@ class AlterManualEventGroup {
                 ->set_placement( 'left' );
 
             $event_program_field = ( new Field\Wysiwyg( $strings['event_program']['label'] ) )
-                ->set_key( "fg_manual_event_fields_event_custom_program" )
+                ->set_key( 'fg_manual_event_fields_event_custom_program' )
                 ->set_name( 'event_custom_program' )
                 ->set_toolbar( [ 'bold', 'italic', 'link' ] )
                 ->disable_media_upload()
                 ->set_instructions( $strings['event_program']['instructions'] );
 
             $event_artists_field = ( new Field\Wysiwyg( $strings['event_artists']['label'] ) )
-                ->set_key( "fg_manual_event_fields_event_custom_artists" )
+                ->set_key( 'fg_manual_event_fields_event_custom_artists' )
                 ->set_name( 'event_custom_artists' )
                 ->set_toolbar( [ 'bold', 'italic', 'link' ] )
                 ->disable_media_upload()
                 ->set_instructions( $strings['event_artists']['instructions'] );
 
             $event_price_field = ( new Field\Wysiwyg( $strings['event_price']['label'] ) )
-                ->set_key( "fg_manual_event_fields_event_custom_price" )
+                ->set_key( 'fg_manual_event_fields_event_custom_price' )
                 ->set_name( 'event_custom_price' )
                 ->set_toolbar( [ 'bold', 'italic', 'link' ] )
                 ->disable_media_upload()
                 ->set_instructions( $strings['event_price']['instructions'] );
 
             $event_links_field = ( new Field\Repeater( $strings['event_links']['label'] ) )
-                ->set_key( "fg_manual_event_fields_event_custom_links" )
+                ->set_key( 'fg_manual_event_fields_event_custom_links' )
                 ->set_name( 'event_custom_links' )
                 ->set_instructions( $strings['event_links']['instructions'] );
 
             $event_link_field = ( new Field\Link( $strings['event_link']['label'] ) )
-                ->set_key( "fg_manual_event_fields_event_link" )
+                ->set_key( 'fg_manual_event_fields_event_link' )
                 ->set_name( 'event_custom_link' )
                 ->set_instructions( $strings['event_link']['instructions'] );
 

--- a/lib/ACF/AlterQuoteData.php
+++ b/lib/ACF/AlterQuoteData.php
@@ -52,7 +52,6 @@ class AlterQuoteData {
 
         return $data;
     }
-
 }
 
 ( new AlterQuoteData() );

--- a/lib/ACF/Layouts/HeroLayout.php
+++ b/lib/ACF/Layouts/HeroLayout.php
@@ -44,27 +44,27 @@ class HeroLayout extends Layout {
         $key = $this->get_key();
 
         $strings = [
-            'image'         => [
+            'image'       => [
                 'label'        => 'Kuva',
                 'instructions' => '',
             ],
-            'title'         => [
+            'title'       => [
                 'label'        => 'Otsikko',
                 'instructions' => '',
             ],
-            'title_image'         => [
+            'title_image' => [
                 'label'        => 'Otsikon taustakuva',
                 'instructions' => '',
             ],
-            'description'   => [
+            'description' => [
                 'label'        => 'Kuvaus',
                 'instructions' => '',
             ],
-            'link'          => [
+            'link'        => [
                 'label'        => 'Painike',
                 'instructions' => '',
             ],
-            'align'         => [
+            'align'       => [
                 'label'        => 'Tekstin tasaus',
                 'instructions' => '',
             ],

--- a/lib/ACF/Layouts/KeyFiguresLayout.php
+++ b/lib/ACF/Layouts/KeyFiguresLayout.php
@@ -44,10 +44,10 @@ class KeyFiguresLayout extends Layout {
     public function add_layout_fields(): void {
         $strings = [
             'background_image'      => [
-                'label'        => 'Taustakuva',
+                'label' => 'Taustakuva',
             ],
             'text_background_image' => [
-                'label'        => 'Numerotekstin taustakuva',
+                'label' => 'Numerotekstin taustakuva',
             ],
         ];
 

--- a/lib/ACF/Layouts/KeyFiguresLayout.php
+++ b/lib/ACF/Layouts/KeyFiguresLayout.php
@@ -38,7 +38,7 @@ class KeyFiguresLayout extends Layout {
     /**
      * Add layout fields.
      *
-     * @return array
+     * @return void
      * @throws Exception In case of invalid option.
      */
     public function add_layout_fields(): void {

--- a/lib/ACF/Layouts/TimelineLayout.php
+++ b/lib/ACF/Layouts/TimelineLayout.php
@@ -48,7 +48,7 @@ class TimelineLayout extends Layout {
                 'label'        => 'Osiot',
                 'instructions' => '',
             ],
-            'image'     => [
+            'image'    => [
                 'label'        => 'Kuva',
                 'instructions' => '',
             ],

--- a/lib/ACF/Layouts/TimelineLayout.php
+++ b/lib/ACF/Layouts/TimelineLayout.php
@@ -105,7 +105,6 @@ class TimelineLayout extends Layout {
             $content_field,
         ] );
 
-
         try {
             $this->add_fields(
                 \apply_filters(

--- a/lib/ACFController.php
+++ b/lib/ACFController.php
@@ -2,7 +2,7 @@
 
 namespace TMS\Theme\Savel;
 
-use \TMS\Theme\Base;
+use TMS\Theme\Base;
 /**
  * Class ACFController
  *
@@ -18,5 +18,4 @@ class ACFController extends Base\ACFController implements Base\Interfaces\Contro
     protected function get_base_dir(): string {
         return __DIR__ . '/ACF';
     }
-
 }

--- a/lib/Assets.php
+++ b/lib/Assets.php
@@ -78,7 +78,7 @@ class Assets extends \TMS\Theme\Base\Assets implements \TMS\Theme\Base\Interface
     /**
      * Add SVG definitions to footer.
      */
-    private function include_savel_svg_icons() : void {
+    private function include_savel_svg_icons(): void {
         $svg_icons_path = \get_stylesheet_directory() . '/assets/dist/icons-savel.svg';
 
         if ( is_file( $svg_icons_path ) ) {

--- a/lib/ThemeSupports.php
+++ b/lib/ThemeSupports.php
@@ -37,12 +37,12 @@ class ThemeSupports implements Controller {
         );
     }
 
-        /**
+    /**
      * ACF layout brand color field choices
      *
      * @return string[]
      */
-    private function acf_image_shape_choices() : array {
+    private function acf_image_shape_choices(): array {
         return [
             'default'                         => 'Ei muotoa',
             'shape shape--summertime-sadness' => 'Apila',

--- a/models/page-extend.php
+++ b/models/page-extend.php
@@ -16,7 +16,7 @@ class PageExtend extends BaseModel {
     /**
      * Hooks
      */
-    public function hooks() : void {
+    public function hooks(): void {
         \add_filter( 'tms/theme/breadcrumbs/show_breadcrumbs_in_header', fn() => false );
     }
 
@@ -25,7 +25,7 @@ class PageExtend extends BaseModel {
      *
      * @return int|null
      */
-    public function hero_image() : ?int {
+    public function hero_image(): ?int {
         return \has_post_thumbnail()
             ? \get_post_thumbnail_id()
             : null;

--- a/models/single-manual-event-cpt.php
+++ b/models/single-manual-event-cpt.php
@@ -102,10 +102,19 @@ class SingleManualEventCpt extends PageEvent {
         $event->recurring_event = false;
         $event->end_datetime    = null;
 
-        $normalized_event = ManualEvent::normalize_event( $event );
-        $event_price      = $normalized_event['price'][0]['price'];
-        $event_location   = $normalized_event['location']['name'];
-        $weekday_prefix   = \date_i18n( 'D', strtotime( $event->start_datetime ) );
+        $normalized_event          = ManualEvent::normalize_event( $event );
+        $event_location            = $normalized_event['location']['name'];
+        $weekday_prefix            = \date_i18n( 'D', strtotime( $event->start_datetime ) );
+        $normalized_event['price'] = [
+            [
+                'price'       => $event->price_is_free
+                    ? __( 'Free', 'tms-theme-base' )
+                    : $event->price['price_price'],
+                'info_url'    => [
+                    'url'   => $event->price['price_info_url']['url'] ?? '',
+                ],
+            ],
+        ];
 
         return [
             'normalized'               => $normalized_event,
@@ -117,7 +126,6 @@ class SingleManualEventCpt extends PageEvent {
             'links_title'              => \__( 'Links', 'tms-theme-savel' ),
             'weekday_prefix'           => $weekday_prefix,
             'location_price_separator' => $event_location ? ', ' : '',
-            'event_price'              => $event_price,
         ];
     }
 }

--- a/models/single-manual-event-cpt.php
+++ b/models/single-manual-event-cpt.php
@@ -107,11 +107,11 @@ class SingleManualEventCpt extends PageEvent {
         $weekday_prefix            = \date_i18n( 'D', strtotime( $event->start_datetime ) );
         $normalized_event['price'] = [
             [
-                'price'       => $event->price_is_free
+                'price'    => $event->price_is_free
                     ? __( 'Free', 'tms-theme-base' )
                     : $event->price['price_price'],
-                'info_url'    => [
-                    'url'   => $event->price['price_info_url']['url'] ?? '',
+                'info_url' => [
+                    'url' => $event->price['price_info_url']['url'] ?? '',
                 ],
             ],
         ];

--- a/partials/page-combined-events-list.dust
+++ b/partials/page-combined-events-list.dust
@@ -11,7 +11,7 @@
                         </h1>
 
                         {?description}
-                            <div class="mt-5">
+                            <div class="mt-5 has-text-centered">
                                 {description|kses}
                             </div>
                         {/description}

--- a/partials/single-manual-event-cpt.dust
+++ b/partials/single-manual-event-cpt.dust
@@ -38,14 +38,14 @@
                         <div class="columns">
                             <div class="column">
                                 {?event.normalized.short_description}
-                                    <div class="entry__content is-content-grid mb-8 has-text-centered">
+                                    <div class="entry__content is-content-grid has-text-centered">
                                         <p class="mt-6 mb-6 has-text-large">
                                             {event.normalized.short_description|kses}
                                         </p>
                                     </div>
                                 {/event.normalized.short_description}
 
-                                <div class="entry__info-group pt-5 pb-5">
+                                <div class="entry__info-group pt-5 pb-5 mt-10">
                                     {>"views/single-dynamic-event/single-dynamic-event-info" /}
                                 </div>
 


### PR DESCRIPTION
Severa-ID: 2108
Severa-kuvaus: TMS-1116 Ilmainen tapahtuma -kytkimessä nyt virhe
Task: https://hiondigital.atlassian.net/browse/TMS-1116

## Description

Add logic to single-manual-event model to show "Free" price is the event is free.
This functionality is present in the base-theme + plugin combo, but has been changed to this theme hence the multiple changes for manual-event CPT and needed to be added afterwards.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
