### PR TITLE
TMS-1155: Fix screen-reader text for mobile-nav dropdowns

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1155: Fix screen-reader text for mobile-nav dropdowns
+
 ## [1.1.7] - 2025-04-30
 
 - TMS-1139: Add another link-button to CTA-component

--- a/partials/ui/menu/fly-out-nav.dust
+++ b/partials/ui/menu/fly-out-nav.dust
@@ -7,7 +7,7 @@
             </button>
 
             {^Header.hide_flyout_primary}
-                {@menu menu_name="primary" depth="2" ul_id="js-navbar-menu" ul_classes="bulmally-navbar fly-out-nav__primary" icon_class="{Header.colors.fly_out_nav.link_icon}" menuitem_partial="ui/menu/menu-item" /}
+                {@menu menu_name="primary" depth="2" ul_id="js-navbar-menu" ul_classes="bulmally-navbar fly-out-nav__primary" icon_class="{Header.colors.fly_out_nav.link_icon}" menuitem_partial="ui/menu/menu-item" data=Header.strings /}
             {/Header.hide_flyout_primary}
 
             {^Header.hide_flyout_secondary}
@@ -17,7 +17,7 @@
             {?PageOnepager.component_nav}
                 <ul class="bulmally-navbar fly-out-nav__primary fly-out-nav__onepager js-scroll-children">
                     {#PageOnepager.component_nav}
-                        {>"ui/menu/menu-item" url="#{anchor}" title="{menu_text}" /}
+                        {>"ui/menu/menu-item" url="#{anchor}" title="{menu_text}" data=Header.strings /}
                     {/PageOnepager.component_nav}
                 </ul>
             {/PageOnepager.component_nav}


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1155 Saavutettavuus: Päävalikon alavalikoiden semanttiset puutteet
Task: https://hiondigital.atlassian.net/browse/TMS-1155

## Description
Add missing data to partial for sr-text fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
