### PR TITLE
TMS-1171: Show past events in combined-events archive

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1171: Allow past events to show on combined-events-list template
+
 ## [1.1.9] - 2025-06-05
 
 - TMS-1168: Specific styles for link underlining

--- a/models/page-combined-events-list.php
+++ b/models/page-combined-events-list.php
@@ -373,8 +373,7 @@ class PageCombinedEventsList extends PageEventsSearch {
         $day         = self::get_day_query_var();
         $cat         = self::get_category_query_var();
         $event_order = self::get_order_query_var();
-
-        $meta_query = [];
+        $meta_query  = [];
 
         if ( ! empty( $day ) ) {
             $start_of_day = date( 'Y-m-d H:i:s', strtotime( $day . ' 00:00:00' ) );

--- a/models/page-combined-events-list.php
+++ b/models/page-combined-events-list.php
@@ -122,7 +122,6 @@ class PageCombinedEventsList extends PageEventsSearch {
         $response    = \wp_cache_get( $cache_key, $cache_group );
 
         if ( empty( $response ) ) {
-            $response           = $this->do_get_events( $params );
             $response['events'] = $this->get_manual_events();
 
             if ( ! empty( $response ) ) {
@@ -404,7 +403,7 @@ class PageCombinedEventsList extends PageEventsSearch {
         if ( ! empty( $event_order ) ) {
             if ($event_order === 'date') {
                 $wp_query->set( 'meta_key', 'start_datetime' );
-                $wp_query->set( 'orderby', 'meta_value_num' );
+                $wp_query->set( 'orderby', 'meta_value' );
                 $wp_query->set( 'order', 'ASC' );
             } else {
                 $wp_query->set( 'orderby', $event_order );
@@ -413,7 +412,7 @@ class PageCombinedEventsList extends PageEventsSearch {
         } else {
             // Default ordering by start_datetime
             $wp_query->set( 'meta_key', 'start_datetime' );
-            $wp_query->set( 'orderby', 'meta_value_num' );
+            $wp_query->set( 'orderby', 'meta_value' );
             $wp_query->set( 'order', 'ASC' );
         }
 

--- a/models/page-combined-events-list.php
+++ b/models/page-combined-events-list.php
@@ -374,10 +374,6 @@ class PageCombinedEventsList extends PageEventsSearch {
         $cat         = self::get_category_query_var();
         $event_order = self::get_order_query_var();
 
-        if ( empty( $day ) && empty( $cat ) && empty( $event_order ) ) {
-            return;
-        }
-
         $meta_query = [];
 
         if ( ! empty( $day ) ) {
@@ -415,6 +411,11 @@ class PageCombinedEventsList extends PageEventsSearch {
                 $wp_query->set( 'orderby', $event_order );
                 $wp_query->set( 'order', 'ASC' );
             }
+        } else {
+            // Default ordering by start_datetime
+            $wp_query->set( 'meta_key', 'start_datetime' );
+            $wp_query->set( 'orderby', 'meta_value_num' );
+            $wp_query->set( 'order', 'ASC' );
         }
 
         if ( ! empty( $meta_query ) ) {

--- a/models/page-combined-events-list.php
+++ b/models/page-combined-events-list.php
@@ -123,25 +123,9 @@ class PageCombinedEventsList extends PageEventsSearch {
 
         if ( empty( $response ) ) {
             $response           = $this->do_get_events( $params );
-            // $response['events'] = array_merge(
-            //     $response['events'],
-            //     $this->get_manual_events()
-            // );
             $response['events'] = $this->get_manual_events();
 
-            // Sort events by start datetime objects.
-            // usort( $response['events'], function( $a, $b ) {
-            //     return $a['start_date_raw'] <=> $b['start_date_raw'];
-            // } );
-
             if ( ! empty( $response ) ) {
-                // \wp_cache_set(
-                //     $cache_key,
-                //     $response,
-                //     $cache_group,
-                //     MINUTE_IN_SECONDS * 15
-                // );
-
                 $this->set_pagination_data( count( $response['events'] ) );
 
                 $response['events'] = array_slice( $response['events'], $skip, \get_option( 'posts_per_page' ) );
@@ -161,15 +145,6 @@ class PageCombinedEventsList extends PageEventsSearch {
             'post_type'      => PostType\ManualEvent::SLUG,
             'posts_per_page' => 200, // phpcs:ignore
             'meta_query'     => [
-                'relation'               => 'AND',
-                'start_date_clause'      => [
-                    [
-                        'key'     => 'start_datetime',
-                        'value'   => date( 'Y-m-d' ),
-                        'compare' => '>=',
-                        'type'    => 'DATE',
-                    ],
-                ],
                 'recurring_event_clause' => [
                     [
                         'key'   => 'recurring_event',


### PR DESCRIPTION
Severa-ID: 2665
Severa-kuvaus: TMS-1171 Tampereen Sävel ja Jazz Happening sivustot, manuaaliset tapahtumat ei saa vanheta/poistua
Task: https://hiondigital.atlassian.net/browse/TMS-1171

## Description

Show also past events in archive, ensure the default order to be by date

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)